### PR TITLE
Add quick variants of ffill and nafill(0)

### DIFF
--- a/recipys/step.py
+++ b/recipys/step.py
@@ -111,9 +111,9 @@ class Step:
 
 class StepImputeFill(Step):
     """Uses pandas' internal `nafill` function to replace missing values.
-    
     See `pandas.DataFrame.nafill` for a description of the arguments.
     """
+
     def __init__(self, sel=all_predictors(), value=None, method=None, limit=None):
         super().__init__(sel)
         self.desc = f"Impute with {method if method else value}"
@@ -130,9 +130,10 @@ class StepImputeFill(Step):
 class StepImputeFastZeroFill(Step):
     """Quick variant of pandas' internal `nafill(value=0)` for grouped dataframes.
     """
+
     def __init__(self, sel=all_predictors()):
         super().__init__(sel)
-        self.desc = f"Impute quickly with 0"
+        self.desc = "Impute quickly with 0"
 
     def transform(self, data):
         new_data = self._check_ingredients(data)
@@ -148,20 +149,21 @@ class StepImputeFastForwardFill(Step):
 
     Note: this variant does not allow for setting a limit.
     """
+
     def __init__(self, sel=all_predictors()):
         super().__init__(sel)
-        self.desc = f"Impute with fast ffill"
+        self.desc = "Impute with fast ffill"
 
     def transform(self, data):
         new_data = self._check_ingredients(data)
 
         # Use cumsum (which is optimised for grouped frames) to figure out which
-        # values should be left at NaN, then ffill on the ungrouped dataframe.
-        # Adopted from: https://stackoverflow.com/questions/36871783/fillna-forward-fill-on-a-large-dataframe-efficiently-with-groupby
+        # values should be left at NaN, then ffill on the ungrouped dataframe. Adopted from:
+        # https://stackoverflow.com/questions/36871783/fillna-forward-fill-on-a-large-dataframe-efficiently-with-groupby
         nofill = pd.notnull(new_data).groupby(data.keys).cumsum()
         new_data[self.columns] = new_data[self.columns].ffill()
         for col in self.columns:
-            new_data.loc[nofill[col].to_numpy()==0, col] = np.nan
+            new_data.loc[nofill[col].to_numpy() == 0, col] = np.nan
 
         return new_data
 
@@ -207,11 +209,11 @@ class StepHistorical(Step):
     """
 
     def __init__(
-        self,
-        sel: Selector = all_numeric_predictors(),
-        fun: Accumulator = Accumulator.MAX,
-        suffix: str = None,
-        role: str = "predictor",
+            self,
+            sel: Selector = all_numeric_predictors(),
+            fun: Accumulator = Accumulator.MAX,
+            suffix: str = None,
+            role: str = "predictor",
     ):
         super().__init__(sel)
 
@@ -270,12 +272,12 @@ class StepSklearn(Step):
     """
 
     def __init__(
-        self,
-        sklearn_transformer: object,
-        sel: Selector = all_predictors(),
-        columnwise: bool = False,
-        in_place: bool = True,
-        role: str = "predictor",
+            self,
+            sklearn_transformer: object,
+            sel: Selector = all_predictors(),
+            columnwise: bool = False,
+            in_place: bool = True,
+            role: str = "predictor",
     ):
         super().__init__(sel)
         self.desc = f"Use sklearn transformer {sklearn_transformer.__class__.__name__}"
@@ -358,10 +360,10 @@ class StepSklearn(Step):
 
 class StepResampling(Step):
     def __init__(
-        self,
-        new_resolution: str = "1h",
-        accumulator_dict: Dict[Selector, Accumulator] = {all_predictors(): Accumulator.LAST},
-        default_accumulator: Accumulator = Accumulator.LAST,
+            self,
+            new_resolution: str = "1h",
+            accumulator_dict: Dict[Selector, Accumulator] = {all_predictors(): Accumulator.LAST},
+            default_accumulator: Accumulator = Accumulator.LAST,
     ):
         """This class represents a step in a recipe.
 
@@ -436,11 +438,11 @@ class StepScale:
     """
 
     def __new__(
-        cls,
-        sel: Selector = all_numeric_predictors(),
-        with_mean: bool = True,
-        with_std: bool = True,
-        in_place: bool = True,
-        role: str = "predictor",
+            cls,
+            sel: Selector = all_numeric_predictors(),
+            with_mean: bool = True,
+            with_std: bool = True,
+            in_place: bool = True,
+            role: str = "predictor",
     ):
         return StepSklearn(StandardScaler(with_mean=with_mean, with_std=with_std), sel=sel, in_place=in_place, role=role)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 """The setup script."""
 from pathlib import Path
-from setuptools import setup, find_packages
+from setuptools import setup
 
 root_path = Path(__file__).resolve().parent
 


### PR DESCRIPTION
`nafill` used in the standard `StepImputeFill` is extremely slow for large grouped dataframes. This PR implements variants that are less flexible than the basic `nafill` but are magnitudes faster. 